### PR TITLE
A few suggestions for the v2 pipeline

### DIFF
--- a/long_read_circRNA
+++ b/long_read_circRNA
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import sys

--- a/long_read_circRNA
+++ b/long_read_circRNA
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 import argparse
 import sys

--- a/scripts/novel_exons_and_alternative_usage_v7.0.sh
+++ b/scripts/novel_exons_and_alternative_usage_v7.0.sh
@@ -280,6 +280,7 @@ bedtools coverage -a introns.uniq.exon_remove.bed -b $sample.psl.bed > $sample.i
 cat $sample.circRNA_candidates.annotated.txt | grep -v internal_circRNA_name | awk 'OFS="\t"{print $2,$3,$4,$1,$6,$7}' | sortBed | bedtools map -c 4 -o distinct -a $sample.introns.uniq.exon_remove.coverage.bed -b - | awk 'OFS="\t"{print $0}' > $sample.introns.uniq.exon_remove.coverage.circ.bed
 cat $sample.introns.uniq.exon_remove.coverage.circ.bed | grep circ_ >  $sample.introns.uniq.exon_remove.coverage.onlyCirc.bed
 # Mapping novel exons on introns
+# This step fails on bedtools==2.30.0!
 mapBed -s -F 1.0 -c 4 -o distinct_only -a $sample.introns.uniq.exon_remove.coverage.onlyCirc.bed -b $sample.novel.exons.2reads.bed > $sample.introns.uniq.exon_remove.coverage.onlyCirc.novelExonMap.bed
 
 # List of all unique introns in circRNA regions:


### PR DESCRIPTION
Hi Morten,

Thank you for the improved version of the pipeline.

I had a few suggestions, mainly regarding the location of `env` which on my Debian-based systems always seems to be under `/usr/bin/env` instead of `/bin/env`.

Moreover, I've changed `python` to `python3`, as python is not automatically a shortcut to python3 and the script requires python >=3.5 to run.

Lastly, bedtools==2.30.0 map functions does not work as expected and yields an error - I've opened an issue with the bedtools developer.

Let me know what you think,

Tobias